### PR TITLE
Add hash-based permalink functionality for course navigation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -470,7 +470,24 @@
             document.getElementById(id).innerHTML = contents[id];
         }
 
-        function showContent(targetId) {
+        // Hash mapping for permalinks
+        const contentToHash = {
+            'content-0': 's0-orientation',
+            'content-1': 's1-smart-tool',
+            'content-2': 's2-dialog',
+            'content-3': 's3-thinking-accelerator',
+            'content-4': 's4-expert-team'
+        };
+        
+        const hashToContent = {
+            's0-orientation': 'content-0',
+            's1-smart-tool': 'content-1',
+            's2-dialog': 'content-2',
+            's3-thinking-accelerator': 'content-3',
+            's4-expert-team': 'content-4'
+        };
+
+        function showContent(targetId, updateHash = true) {
             contentSections.forEach(section => {
                 section.classList.toggle('hidden', section.id !== targetId);
             });
@@ -478,6 +495,34 @@
                 link.classList.toggle('active', link.dataset.target === targetId);
             });
             mainContent.scrollTop = 0; // Scroll to top
+            
+            // Update URL hash for permalink functionality
+            if (updateHash) {
+                const hash = contentToHash[targetId];
+                if (targetId === 'content-0') {
+                    // Remove hash for content-0 (home page)
+                    history.pushState(null, null, window.location.pathname);
+                } else if (hash) {
+                    history.pushState(null, null, `#${hash}`);
+                }
+            }
+        }
+
+        // Handle hash changes (back/forward buttons, direct links)
+        function handleHashChange() {
+            const hash = window.location.hash.slice(1); // Remove #
+            let targetId;
+            
+            if (hash === '' || hash === 's0-orientation') {
+                targetId = 'content-0';
+            } else if (hashToContent[hash]) {
+                targetId = hashToContent[hash];
+            } else {
+                // Invalid hash, default to content-0
+                targetId = 'content-0';
+            }
+            
+            showContent(targetId, false); // Don't update hash to avoid infinite loop
         }
 
         sidebarLinks.forEach(link => {
@@ -570,8 +615,11 @@
         });
 
 
-        // Initialize first page
-        showContent('content-0');
+        // Add hash change event listener
+        window.addEventListener('hashchange', handleHashChange);
+        
+        // Initialize page based on current hash
+        handleHashChange();
     });
     </script>
 </body>


### PR DESCRIPTION
- Implement semantic URL hashes for each course section:
  - #s0-orientation (第0回 オリエンテーション)
  - #s1-smart-tool (第1回 AIを「賢い道具」に)
  - #s2-dialog (第2回 AIとの「対話」)
  - #s3-thinking-accelerator (第3回 AIは「思考加速ツール」)
  - #s4-expert-team (第4回 AIを「専門家チーム」に)
- Add bidirectional hash-content mapping for navigation
- Support browser back/forward buttons and direct link access
- Maintain existing UI interactions (sidebar, next buttons)
- Update URL hash on navigation for shareable links

🤖 Generated with [Claude Code](https://claude.ai/code)