### PR TITLE
Add og_image.png display to orientation page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -147,6 +147,9 @@
                 <header class="text-center mb-16">
                     <h1 class="text-4xl md:text-5xl font-bold text-[#A58A73] mb-4">生成AI入門講座 第0回</h1>
                     <p class="text-lg text-gray-600">オリエンテーション</p>
+                    <div class="mt-8">
+                        <img src="og_image.png" alt="生成AI入門講座 - AIを思考のパートナーに" class="mx-auto rounded-lg shadow-lg max-w-md h-auto">
+                    </div>
                 </header>
                 <main>
                     <section id="introduction" class="mb-20">


### PR DESCRIPTION
- Display og_image.png in the header section of orientation page (content-0)
- Image is centered with rounded corners and shadow
- Set appropriate size with max-w-md for better visual balance

🤖 Generated with [Claude Code](https://claude.ai/code)